### PR TITLE
Finalization

### DIFF
--- a/cs244b_project/src/blockchain/chain.rs
+++ b/cs244b_project/src/blockchain/chain.rs
@@ -76,7 +76,8 @@ impl Chain for LocalChain {
     }
     fn copy_up_to_height(&self, height: u64) -> LocalChain {
         // +1 because slice end is exclusive
-        let copy_idx = usize::try_from(height + 1).expect("could not cast u64 to usize");
+        // +1 because height does not include genesis block -- it's distance *from* genesis block
+        let copy_idx = usize::try_from(height + 2).expect("could not cast u64 to usize");
         Self {
             blocks: self.blocks[..copy_idx].to_vec(),
         }


### PR DESCRIPTION
- (1) Correct finalization logic. Previously, "copy up to height" was not taking into account the fact that height doesn't include genesis block, so was incorporating an off by one error. I.e., out of 3 notarized consecutive blocks, only the first was getting finalized. 
- (2) Use the .length() utility on chain, instead of chain.blocks.len() 